### PR TITLE
Add `all` rule toMakefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ compiler:
   - g++
 # Setup different environments to test
 env:
-  - target=lib
-  - target=examples
+  - target=dev
 
 # Setup repos etc before installation
 before_install:
@@ -16,8 +15,7 @@ install:
   # install g++ 4.6
   - sudo apt-get install -qq g++-4.6;
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.6 50;
-  - g++ --version
-  
+
   # install GNU make
   - sudo apt-get install build-essential
   - g++ --version
@@ -25,5 +23,4 @@ install:
 # command to run tests
 script:
   - cd build
-  - if [ "$target" == "lib"      ]; then make socket-cpp.so; fi;
-  - if [ "$target" == "examples" ]; then make examples;      fi;
+  - make

--- a/build/Makefile
+++ b/build/Makefile
@@ -17,7 +17,9 @@ CXX      = g++
 CXXFLAGS = -g -I$(LIB_INC_DIR)
 LDFLAGS  = -shared -fpic
 
-default: $(TARGET)
+default: all
+
+all: $(TARGET) examples
 
 $(TARGET): $(OBJ_FILES)
 	@mkdir -p $(LIB_DIST_DIR)


### PR DESCRIPTION
add new all rule to Makefile which build both `socket-cpp.so` and
examples, and update travis-ci to make one build enviroment as
make no will build both at once.
